### PR TITLE
Adds draft of mechanism reuse prevention

### DIFF
--- a/paper/analysis-security.tex
+++ b/paper/analysis-security.tex
@@ -136,7 +136,7 @@ does not include \(\cid\) whereas \[
 does.
 Thus the verification process differs for the two types of proofs.
 (An alternative approach would have been to compute them differently, \eg 
-\(\pid = \AC[PRF]_{\sk}(x)\) but \(\wid = \AC[\overline{PRF}]_{\sk}(x)\).
+\(\pid = \AC[PRF]_{\sk}(x) = g_T^{\sk+x}\) but \(\wid = g_T^{\sk+x+1}\).)
 
 %\paragraph{Forging proof shares}
 %


### PR DESCRIPTION
This adds mechanism reuse to the security analysis.

In this version we don't need to modify the PRF. The proofs issued by witnesses and proofs by participants differ in that witnesses don't include cid. Thus a witness proof will never verify as a participant proof.

[paper.pdf](https://github.com/dbosk/ProtestVerif/files/2047913/paper.pdf)
