### PR TITLE
Terminology: ledger, storage, time-stamping service

### DIFF
--- a/paper/adversary-model.tex
+++ b/paper/adversary-model.tex
@@ -6,8 +6,8 @@
 % capabilities (\ie more auxiliary information).
 
 There are three players: the protester (with identity) \(P\), a witness (with 
-identity) \(W\) and the time-stamping storage \(\TS\) (that will contain the 
-set of all proof shares, \(\pshs\)).
+identity) \(W\) and a ledger~\(\TS\) (\ie time-stamping storage, that will 
+contain the set of all proof shares, \(\pshs\)).
 The protester \(P\) and the witness \(W\) communicate some protocol data,
 \(d_{P,W}(\cid, P)\), and records when the communication occurred \(t_{P,W}\).
 The protester \(P\) communicates with \(\TS\), in which \(\TS\) only learns 

--- a/paper/preamble.tex
+++ b/paper/preamble.tex
@@ -141,10 +141,9 @@
 \NewFunction{\str}{\varsigma}
 \NewScheme{\TS}{L}
 \NewAlgorithm{\TSget}{\TS.\!GetStartPoint}
-\NewAlgorithm{\TSstamp}{\TS.\!Submit}
+\NewAlgorithm{\TSsubmit}{\TS.\!Submit}
 \NewAlgorithm{\TSverify}{\TS.\!Verify}
 \NewAlgorithm{\TStime}{\TS.\!Time}
-\NewAlgorithm{\TSstore}{\TS.\!Submit}
 \NewAlgorithm{\PKprove}{PK.\!Prove}
 \NewAlgorithm{\PKverify}{PK.\!Verify}
 \NewAlgorithm{\SPKprove}{SPK.\!Prove}

--- a/paper/protocol.tex
+++ b/paper/protocol.tex
@@ -140,10 +140,12 @@ compute an identifier for the cause by hashing the manifesto,
 \(\cid\gets \Hash[\mfst]\) (and comparing the result to that received
 from the organizer, we omit this in the protocol for readibility).
 Afterwards, this identifier is used to create the protest-specific identifier 
-for the protester, \(\pid\gets \ACprf[_{\sk_P}][\cid]\) (see 
-\cref{fig:ProofFig} and \cref{ACprfAlg}).
-The protester should also receive a time-correlated random value from the 
-time-stamping service, \(t_s\gets \TSget\).
+for the protester, \(\pid\gets \ACprf[_{\sk_P}][\cid]\)%
+% (see \cref{fig:ProofFig} and \cref{ACprfAlg} in the appendix for details of 
+%the algorithms)%
+.
+The protester should also fetch a time-correlated random value, \(\t_s\), from 
+\(\TS\), \(t_s\gets \TSget\).
 
 
 \emph{Joining as a witness: \(t_s'\gets \CROCUSjoin_W\).}
@@ -157,10 +159,10 @@ set the start of the time interval of creation for the proof share.
 In the participation phase, the protester and 
 the witness construct the proof share of the protester (\cref{fig:ProofFig}).
 
-The protester sends \(\pid\) to the witness.
+The protester sends \(\pid\) and \(t_s\) to the witness.
 Then they run the protocol \[
   \Proto{\ACproveSig[\spk, k, r, \sigma]}{\ACverifySig[\spk, \ssk]}
-\] (see \cref{ACacAlg}).
+\] (see \cref{ACacAlg}), \(k\) and \(r\) are part of \(\sk_P\).
 Note that the \acf{PK} in \cref{ACacAlg} must be
 run as a \iacf{PPK}, which we do by distance bounding.
 If the protocol succeeds, the witness will compute \(\wid \gets 
@@ -168,11 +170,11 @@ If the protocol succeeds, the witness will compute \(\wid \gets
 
 
 \emph{Submission: \(\psh_P\gets \CROCUSsubmit[_P][\cid, \pid, \wid, t_s, t_s',  l]\).}
-The protester commits the proof-share data to the 
-time-stamping service and receives the proof of commitment, \(t_e\gets 
-  \TSstamp[\Hash[\cid, \pid, \wid, t_s, t_s', l]]\). The sooner this
-  is done, the higher the precision for the time-dependent eligibility criterion
-  will be for later counting. 
+The protester commits the proof-share data to the ledger~\(L\) and receives the 
+proof of commitment, \(t_e\gets \TSsubmit[\Hash[\cid, \pid, \wid, t_s, t_s', 
+  l]]\).
+The sooner this is done, the higher the precision for the time-dependent 
+eligibility criterion will be for later counting.
 The remaining operations are not time critical.
 
 The protester computes \iac{NIZK} proof \(\corr_{\pid}\), which shows the 
@@ -188,13 +190,12 @@ More specifically,
 \end{multline*}
 Finally, the protester uploads the tuple \[
   \psh_P = (\cid, \pid, \wid, t_s, t_s', t_e, l, \corr_{\pid})
-\] for permanent storage.
+\] for permanent storage, \(\TSsubmit[\psh_P]\).
 
 \emph{Submission: \(\psh_W\gets \CROCUSsubmit[_W][\cid, \pid, \wid, t_s, t_s', 
     l]\).}
 The witness should, just as the protester, commit the proof-share data to the 
-time-stamping service (\ie the ledger), \(t_e'\gets \TSstamp[\Hash[\cid, \pid, \wid, t_s, t_s', 
-  l]]\).
+ledger, \(t_e'\gets \TSstamp[\Hash[\cid, \pid, \wid, t_s, t_s', l]]\).
 %(This is to make the time interval as early as possible, whoever is the faster 
 %will submit it.) \sonja{but both do}
 Then, without any time requirements, the witness computes \iac{NIZK} proof 
@@ -209,7 +210,7 @@ Then, without any time requirements, the witness computes \iac{NIZK} proof
 \end{multline*}
 Finally, the witness uploads the tuple \[
   \psh_W = (\cid, \pid, \wid, t_s, t_s', t_e', l, \corr_{\wid})
-\] for permanent storage on the ledger.
+\] for permanent storage on the ledger, \(\TSsubmit[\psh_W]\).
 
 
 \begin{figure*}
@@ -288,9 +289,9 @@ Finally, the witness uploads the tuple \[
 % strength functions.
 
 
-To count or verify the participation count for a protest \(\prtst\) with identifier 
-\(\cid_0\), a verifier must download from the storage system \(\TS\) the set 
-\(\pshs_{\cid_0}\) of all \(s_P\) and \(s_W\) tuples containing \(\cid_0\).
+To count or verify the participation count for a protest \(\prtst\) with 
+identifier \(\cid_0\), a verifier must download the set \(\pshs_{\cid_0}\) of 
+all \(s_P\) and \(s_W\) tuples containing \(\cid_0\) from the ledger~\(\TS\).
 Then from \(\pshs_{\cid_0}\), a verifier can build, in succession,
 \begin{enumerate*}
 \item the valid proof shares \(s_j^{(i)}\) for all matching pairs \((s_P, 
@@ -361,7 +362,8 @@ digitally signing each proof share\footnote{%
   group or ring signature scheme for a set of trusted witnesses, \eg
   members of an independent journalist association.  Then one learns
   that at least one member of this set of trusted witnesses must have
-  been there.  }.
+  been there.
+}.
 
 Note that, thanks to the \((\str,\theta)\)-eligibility criterion
 (\cref{DefParticipationCount}), the method of counting is extremely

--- a/paper/timestamp.tex
+++ b/paper/timestamp.tex
@@ -1,21 +1,23 @@
 \subsection{Time-stamping and storage: ledger}%
 \label{StorageProperties}\label{timestamp}\label{ledger}
 
-We need a robust time-stamping service, \(\TS\), which implements the \(\TSget\), \(\TSstamp\) and \(\TStime\) requests such that
-\simon{\enquote{request} feels weird to me. Are we sure that's the right word?}
+We need a robust time-stamping and storage service (\ie a ledger), \(\TS\), 
+which implements the following oracles:
 \begin{itemize}
-  \item \(\rho \gets \TSget\) yields a value \(\rho\) at time \(t\), \(\rho\) 
-    is difficult to guess before time \(t\) and \(\TStime[\rho] = t\);
-  \item \(\pi\gets \TSstamp[x]\) yields a value \(\pi\) at time \(t\) such that 
-    \(\TSverify[x, \pi]\to \top\) and \(\TStime[\pi] = t\).
-  \item \(\TSstore[x]\) stores \(x\) permanently and publicly readable.
+  \item \(\rho \gets \TSget\) yields a value \(\rho\) at time \(t\) such that 
+    \(\rho\) is difficult to guess before time \(t\) and \(\TStime[\rho] = t\);
+  \item \(\pi\gets \TSsubmit[x]\) stores \(x\) permanently and yields a value 
+    \(\pi\) at time \(t\) such that \(\TSverify[x, \pi]\to \top\) and 
+    \(\TStime[\pi] = t\).
 \end{itemize}
 
-With these building blocks, we can ensure that a message \(m\) is created within the time interval \(\interval{t_0}{t_1}\).
-After time \(t_0\), a user requests \(\rho_{t_0}\gets \TSget\).
-Before time \(t_1\), a user submits \(h\gets \Hash[m, \rho_{t_0}]\) to the time-stamping service to get \(\pi_{t_1}\gets \TSstamp[h]\).
-
-The tuple \((\rho_{t_0}, m, \pi_{t_1})\) can be used to prove that \(m\) was created within the time interval \(\interval{t_0}{t_1}\).
+With these building blocks, Alice can prove to a third-party verifier that a 
+message \(m\) was created within the time interval \(\interval{t_0}{t_1}\):
+After time \(t_0\), Alice requests \(\rho_{t_0}\gets \TSget\).
+Before time \(t_1\), Alice submits \(h\gets \Hash[m, \rho_{t_0}]\) to \(\TS\) 
+and gets \(\pi_{t_1}\gets \TSsubmit[h]\).
+The tuple \((\rho_{t_0}, m, \pi_{t_1})\) can be used to prove that \(m\) was 
+created within the time interval \(\interval{t_0}{t_1}\).
 The verifier computes \(h'\gets \Hash[m, \rho_{t_0}]\) and checks whether 
 \(\TSverify[h', \pi_{t_1}] = \top\) and \(\TStime[\rho_{t_0}] \geq t_0\land 
   \TStime[\pi_{t_1}] \leq t_1\).
@@ -28,24 +30,32 @@ value from \(\TSget\).
 resort to only using every \(n\)th output.)
 
 \(\TS\) can be instantiated by an open-membership distributed ledger (\eg a blockchain) such as Bitcoin~\cite{Bitcoin}, secured via Proof-of-Work consensus, or OmniLedger~\cite{OmniLedger}, secured via Byzantine consensus.
-If a blockchain is used for \(\TS\), the \(\TSstamp[x]\) request includes \(x\) in the blockchain and returns the identifier of the block into which \(x\) was included.
+If a blockchain is used for \(\TS\), the \(\TSsubmit[x]\) request includes 
+\(x\) in the blockchain and returns the identifier of the block into which 
+\(x\) was included.
 The \(\TSget\) request returns the hash of the most recent block of the chain 
 (\ie the head).%
 \footnote{In situations where forks are common, it is relatively easy to adapt this process to look at a few blocks before the head and avoid the issue of the stamp becoming invalid later.}
 The returned hash is difficult to predict since it depends on the content of the block, populated by other users and by the creator of the block with additional randomness (\eg nonces and secrets).
 
-Regarding consensus resilience, it is advisable to use a blockchain with a high 
-number of participants and preferably sharing the blockchain with other 
-services.
-The resilience of the Byzantine consensus relies on honest participants outnumbering malicious participants.
-A similar reasoning can be made with Proof-of-Work consensus in which the computing power of the honest participants must be greater than the one of malicious participants.
-In both cases, assuming a majority of honest members in the population, the more participants the merrier.
+Regarding consensus resilience, it is advisable to use a ledger with a high 
+number of participants and preferably sharing the ledger with other services.
+%The resilience of the Byzantine consensus relies on honest participants outnumbering malicious participants.
+%A similar reasoning can be made with Proof-of-Work consensus in which the 
+%computing power of the honest participants must be greater than that of the 
+%malicious participants.
+%In both cases, assuming a majority of honest members in the population, the more participants the merrier.
 We want to share the blockchain with other services due to privacy (and 
-anti-censorship) reasons, analogous to the idea of \enquote{domain fronting}.
+anti-censorship) reasons (analogous to the idea of \enquote{domain fronting}).
 
-We require a few additional properties from \(\TS\) that are already provided by blockchains.
-First, \(\TS\) must be continuously extended, such as in Bitcoin in which blocks are created every 10 minutes on average.
-Second, \(\TS\) must provide \emph{immutability} and availability to any data committed through \(\TSstamp\) to ensure verifiability of the data by anyone at any time.
+We require a few additional properties from \(\TS\) that are already provided 
+by ledgers.
+First, \(\TS\) must be continuously extended, such as in Bitcoin in which 
+blocks are created every 10 minutes on average (this is so that \(\TStime\) can 
+map values from \(\TSget\) to real time).
+Second, \(\TS\) must provide \emph{immutability} and availability to any data 
+committed through \(\TSsubmit\) to ensure verifiability of the data by anyone 
+at any time.
 
 % Since \(\pid\) uniquely identifies \(P\), then if \(t_s^{(\pid)}\) is 
 % \enquote{unique enough}\footnote{%

--- a/paper/verifiability-analysis.tex
+++ b/paper/verifiability-analysis.tex
@@ -39,9 +39,9 @@ the case with \(\TStime\).
 
 According to \cref{TemporallyRelated}, we must also prove that a proof share has not been created after a certain time.
 Otherwise, Grace could argue that the proof share was created after the protest, thus defeating the purpose of our protocol.
-The hash values of the proof shares are committed to the ledger (\(\TSstamp\)), 
-which means that there is a negligible probability that they were created after 
-that:
+The hash values of the proof shares are committed to the ledger 
+(\(\TSsubmit\)), which means that there is a negligible probability that they 
+were created after that:
 Alice would have to choose a value \(y\) in the range of the hash function 
 \(\Hash\) and then find a pre-image \(x\) such that \(y = \Hash[x]\) and \(x\) 
 is a valid proof for the desired protest, at the desired time.
@@ -141,11 +141,11 @@ Thus, the verification process differs for the two types of proofs.
 that their participation proofs (\ie proof shares) are indeed included in the 
 computed count.
 All proof shares (\ie \(\prf_{\pid, \prtst} = (\cid, \pid, \wid, t_s, t_s', 
-  t_e, t_e', l, \corr_\pid, \corr_\wid)\)) are committed to the ledger and 
-available from a public and permanent storage.
+  t_e, t_e', l, \corr_\pid, \corr_\wid)\)) are committed to the ledger~\(\TS\) 
+and available from a public and permanent storage.
 Thus, Alice and Bob can simply check that all of their proof shares are indeed 
 there and the security of individual verifiability depends on the properties of 
-the ledger and storage (\(\TS\), \cref{timestamp}).
+the ledger (\cf \cref{timestamp}).
 
 We assumed an honest-but-curious adversary controlling \(\TS\)\footnote{%
   We note that, in general, distributed (decentralized) ledgers cannot 


### PR DESCRIPTION
This fixes #176. Now we use ledger throughout, and \TS yields L.